### PR TITLE
User configs now support min_magnitude and max_pvalue

### DIFF
--- a/backend/api/user.py
+++ b/backend/api/user.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, Depends
+from typing import Optional
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from backend.auth import auth
@@ -11,8 +12,29 @@ class Notifiers(BaseModel):
     slack: bool
 
 
+class Core(BaseModel):
+    """
+    Configuration params for the core of Nyrkiö.
+
+    Note that no values are optional, so the user must provide both
+    min_magnitude and max_pvalue if they want to update the config.
+    """
+
+    min_magnitude: float
+    max_pvalue: float
+
+
 class UserConfig(BaseModel):
-    notifiers: Notifiers
+    notifiers: Optional[Notifiers] = None
+    core: Optional[Core] = None
+
+
+def validate_config(config: UserConfig):
+    """Provide extra validation for the UserConfig model that Pydantic can't handle."""
+    if config.core is not None and config.core.max_pvalue > 1.0:
+        raise HTTPException(
+            status_code=400, detail="max_pvalue must be less than or equal to 1.0"
+        )
 
 
 @user_router.get("/config")
@@ -26,6 +48,7 @@ async def get_user_config(user: User = Depends(auth.current_active_user)):
 async def set_user_config(
     config: UserConfig, user: User = Depends(auth.current_active_user)
 ):
+    validate_config(config)
     store = DBStore()
     await store.set_user_config(user, config.model_dump())
 
@@ -34,6 +57,8 @@ async def set_user_config(
 async def update_user_config(
     config: UserConfig, user: User = Depends(auth.current_active_user)
 ):
+    validate_config(config)
+
     store = DBStore()
     json = config.model_dump()
     await store.set_user_config(user, json)

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1,0 +1,12 @@
+class Config:
+    """
+    Configuration settings for the core of Nyrkiö
+
+    Args:
+        min_magnitude (float): The minimum magnitude of a performance change, expressed as a percentage
+        max_pvalue (float): The maximum p-value for a performance change to be considered significant
+    """
+
+    def __init__(self, min_magnitude=0.05, max_pvalue=0.001):
+        self.min_magnitude = min_magnitude
+        self.max_pvalue = max_pvalue

--- a/backend/core/core.py
+++ b/backend/core/core.py
@@ -11,6 +11,7 @@ from hunter.report import Report, ReportType
 from hunter.series import Series, AnalysisOptions
 
 from backend.core.sieve import sieve_cache
+from backend.core.config import Config
 
 """
 This is a description of the core logic of Nyrkiö. It is written in such a way
@@ -64,9 +65,14 @@ class PerformanceTestResult:
 
 
 class PerformanceTestResultSeries:
-    def __init__(self, name):
+    def __init__(self, name, config=None):
         self.results = SortedList(key=lambda r: r.timestamp)
         self.name = name
+
+        if not config:
+            config = Config()
+
+        self.config = config
 
     def add_result(self, result: PerformanceTestResult):
         """
@@ -113,8 +119,8 @@ class PerformanceTestResultSeries:
         )
 
         options = AnalysisOptions()
-        options.min_magnitude = 0.05
-        options.max_pvalue = 0.001
+        options.min_magnitude = self.config.min_magnitude
+        options.max_pvalue = self.config.max_pvalue
 
         change_points = series.analyze(options).change_points_by_time
         report = GitHubReport(series, change_points)


### PR DESCRIPTION
Different users have different requirements and different tests so it makes sense to allow them to configure the min_magnitude and max_pvalue settings for the core code.