### PR TITLE
calc_changes() fix  and also new summary API 

### DIFF
--- a/backend/api/admin.py
+++ b/backend/api/admin.py
@@ -5,7 +5,6 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi_users.exceptions import UserNotExists
 
 from backend.auth import auth
-from backend.core.config import Config
 from backend.db.db import User, DBStore
 
 admin_router = APIRouter(prefix="/admin")
@@ -33,7 +32,6 @@ async def changes(test_path: str, user: User = Depends(auth.current_active_super
     except UserNotExists:
         raise HTTPException(status_code=404, detail="No such user exists")
 
-    store = DBStore()
     test_name = "/".join(test_path.split("/")[1:])
 
     from backend.api.api import calc_changes

--- a/backend/api/admin.py
+++ b/backend/api/admin.py
@@ -35,17 +35,10 @@ async def changes(test_path: str, user: User = Depends(auth.current_active_super
 
     store = DBStore()
     test_name = "/".join(test_path.split("/")[1:])
-    results, _ = await store.get_results(user.id, test_name)
-    disabled = await store.get_disabled_metrics(user.id, test_name)
-
-    config, _ = await store.get_user_config(user.id)
-    config = config.get("core", None)
-    if config:
-        config = Config(**config)
 
     from backend.api.api import calc_changes
 
-    return await calc_changes(test_name, results, disabled, config)
+    return await calc_changes(test_name, user.id)
 
 
 @admin_router.get("/result/{test_path:path}")

--- a/backend/api/api.py
+++ b/backend/api/api.py
@@ -120,12 +120,14 @@ async def get_subtree_summary(
                         summary["oldest_time"] = cp.time
                         summary["oldest_test_name"] = test_name
                         summary["oldest_change_point"] = cp
-                    if first or abs(summary["largest_change"]) < abs(cp.forward_change_percent()):
+                    if first or abs(summary["largest_change"]) < abs(
+                        cp.forward_change_percent()
+                    ):
                         summary["largest_change"] = cp.forward_change_percent()
                         summary["largest_test_name"] = test_name
                         summary["largest_change_point"] = cp
 
-                    summary["total_change_points"] +=1
+                    summary["total_change_points"] += 1
 
         # all_summaries["test_name"] = summary
     return summary

--- a/backend/api/api.py
+++ b/backend/api/api.py
@@ -74,30 +74,61 @@ async def changes(
     return await calc_changes(test_name, user.id, notifiers)
 
 
-# @api_router.get("/result/{test_name_prefix:path}/summary")
-# async def get_subtree_summary(
-#     test_name_prefix: str, user: User = Depends(auth.current_active_user)
-# ) -> Dict:
-#     """
-#     Get all change points for all test results that are in the sub-tree of `test_name_prefix` and
-#     return a summary of that data.
-#
-#     The UI would use this information to show something like "project: 57 change points, the latest
-#     on 2024-04-20".
-#
-#     Note that for this feature we have added pre-computation and storage of change points.
-#     Without such pre-compute, we would here constantly be re-computing all test results of the user!
-#     """
-#     subtree_test_names = await store.get_test_names(user.id, test_name_prefix)
-#
-#     if not subtree_test_names:
-#         raise HTTPException(status_code=404, detail="Not Found")
-#
-#     core_config = await _get_user_config(user.id)
-#
-#     for test_name in subtree_test_names:
-#         change_points = await calc_changes(test_name, results, core_config=core_config)
-#         subtree_changes[test_name] = change_points
+@api_router.get("/result/{test_name_prefix:path}/summary")
+async def get_subtree_summary(
+    test_name_prefix: str, user: User = Depends(auth.current_active_user)
+) -> Dict:
+    """
+    Get all change points for all test results that are in the sub-tree of `test_name_prefix` and
+    return a summary of that data.
+
+    The UI would use this information to show something like "project: 57 change points, the latest
+    on 2024-04-20".
+
+    Note that for this feature we have added pre-computation and storage of change points.
+    Without such pre-compute, we would here constantly be re-computing all test results of the user!
+    """
+    store = DBStore()
+    # all_summaries = {}
+    summary = {
+        "total_change_points": 0,
+        "newest_time": None,
+        "newest_test_name": None,
+        "oldest_time": None,
+        "oldest_test_name": None,
+        "newest_change_point": None,
+        "oldest_change_point": None,
+        "largest_change": None,
+        "largest_test_name": None,
+    }
+    subtree_test_names = await store.get_test_names(user.id, test_name_prefix)
+
+    if not subtree_test_names:
+        raise HTTPException(status_code=404, detail="Not Found")
+
+    for test_name in subtree_test_names:
+        series, change_points = await _calc_changes(test_name, user.id, None)
+        for metric_name, analyzed_series in change_points.items():
+            for metric_name, cp_list in analyzed_series.change_points.items():
+                for cp in cp_list:
+                    first = summary["total_change_points"] == 0
+                    if first or summary["newest_time"] < cp.time:
+                        summary["newest_time"] = cp.time
+                        summary["newest_test_name"] = test_name
+                        summary["newest_change_point"] = cp
+                    if first or summary["oldest_time"] > cp.time:
+                        summary["oldest_time"] = cp.time
+                        summary["oldest_test_name"] = test_name
+                        summary["oldest_change_point"] = cp
+                    if first or abs(summary["largest_change"]) < abs(cp.forward_change_percent()):
+                        summary["largest_change"] = cp.forward_change_percent()
+                        summary["largest_test_name"] = test_name
+                        summary["largest_change_point"] = cp
+
+                    summary["total_change_points"] +=1
+
+        # all_summaries["test_name"] = summary
+    return summary
 
 
 @api_router.get("/results")
@@ -278,7 +309,7 @@ def _build_result_series(
     return series
 
 
-async def calc_changes(test_name, user_id=None, notifiers=None):
+async def _calc_changes(test_name, user_id, notifiers):
     store = DBStore()
     series = None
 
@@ -294,6 +325,11 @@ async def calc_changes(test_name, user_id=None, notifiers=None):
         )
 
     changes = await get_cached_or_calc_changes(user_id, series)
+    return series, changes
+
+
+async def calc_changes(test_name, user_id=None, notifiers=None):
+    series, changes = await _calc_changes(test_name, user_id, notifiers)
     reports = await series.produce_reports(changes, notifiers)
     return reports
 

--- a/backend/db/db.py
+++ b/backend/db/db.py
@@ -754,6 +754,12 @@ class DBStore(object):
         data, meta = separate_meta_one(results[0])
 
         series_last_modified = series_id_tuple[3]
+        if not meta:
+            # Series doesn't have a last_modified field. It probably predates the time we even
+            # had caching for change points.
+            # Caller needs to compute the change_points now.
+            return {}
+
         if meta["last_modified"] < series_last_modified:
             # User has updated the series since the change points were last computed.
             # Caller needs to recompute the change points.


### PR DESCRIPTION
The summary API returns summary data shown in the UI when tests are organized in a hierarchy. This replaces the client side caching with backend caching and also avoids calling Github API unnecesarily.

There's still plenty to optimize: This still iterates over all test names / series and fetches the corresponding change points one series at a time. We could get away with a single db query if we think about what we are doing a bit more thoroughly.

Also the frontend issues one http call for each line. It would be better to just use the parent  prefix/path as the parameter and then return all children in one batch / map.