### PR TITLE
Add padding to line charts

### DIFF
--- a/frontend/src/components/DrawLineChart.jsx
+++ b/frontend/src/components/DrawLineChart.jsx
@@ -212,7 +212,7 @@ export const DrawLineChart = ({
         timestamp={modalData}
         setTimestamp={setModalData}
       />
-      <div className="chart-wrapper">
+      <div className="chart-wrapper p-4">
         <h6 className="text-center">
           {testName}: {metricName}
         </h6>

--- a/frontend/src/components/OrgDashboard.jsx
+++ b/frontend/src/components/OrgDashboard.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 import { TableOrResult } from "./TableOrResult";
-import { SidePanel } from "./SidePanel";
 import { dashboardTypes } from "../lib/utils";
 
 export const OrgDashboard = () => {
@@ -61,7 +60,6 @@ export const OrgDashboard = () => {
 
   return (
     <>
-      <SidePanel />
       <div className="row text-center">
         <h1 className="mb-4">Organization Test Results</h1>
       </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -36,6 +36,7 @@
 
   --bs-body-color: #67748e;
   --bs-body-bg: #ffffff;
+  --bs-body-font-family: Helvetica, Arial, sans-serif;
   --bs-body-font-size: 12pt;
   --bs-heading-color: var(--nyrkio-bear-brown);
   --bs-heading-color2: var(--nyrkio-horn-dark-brown);


### PR DESCRIPTION
This prevents charts from touching or going beyond right side border of screen.

Also change default/body font to Helvetica (Arial). Was Inter.
Having let the new heading forn (Big Shoulders) sink in, I wanted a small "sharpening" of the body font as well. Helvetica is one of the oldest classic fonts, yet remains modern. Just like Nyyrikki.

Most users will never see a difference.