### PR TITLE
Restore dynamic cert generation logic for certbot

### DIFF
--- a/certbot/Dockerfile
+++ b/certbot/Dockerfile
@@ -2,9 +2,8 @@ FROM certbot/certbot:latest
 
 COPY certbot/check-certs.sh /check-certs.sh
 
-#ARG SSL_DOMAIN
-ENV SSL_DOMAIN=nyrkio.com
-ENV DOMAIN=nyrkio.com
+ARG SSL_DOMAIN
+ENV DOMAIN=${SSL_DOMAIN}
 ARG EXTRA_DOMAINS
 ENV EXTRA_DOMAINS=${EXTRA_DOMAINS}
 ENTRYPOINT ["/check-certs.sh"]

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -2,8 +2,8 @@ server {
     listen 80;
     listen 443;
 
-    ssl_certificate /etc/nginx/ssl/live/nyrkio.com/fullchain.pem;
-    ssl_certificate_key /etc/nginx/ssl/live/nyrkio.com/privkey.pem;
+    ssl_certificate /etc/nginx/ssl/live/$DOMAIN/fullchain.pem;
+    ssl_certificate_key /etc/nginx/ssl/live/$DOMAIN/privkey.pem;
 
     server_name .nyrk.io;
 
@@ -20,8 +20,8 @@ server {
     listen 80;
     listen 443;
 
-    ssl_certificate /etc/nginx/ssl/live/nyrkio.com/fullchain.pem;
-    ssl_certificate_key /etc/nginx/ssl/live/nyrkio.com/privkey.pem;
+    ssl_certificate /etc/nginx/ssl/live/$DOMAIN/fullchain.pem;
+    ssl_certificate_key /etc/nginx/ssl/live/$DOMAIN/privkey.pem;
 
     server_name .xn--nyrki-nua.com;
 
@@ -38,7 +38,7 @@ server {
     listen 80;
     listen [::]:80;
 
-    server_name nyrkio.com;
+    server_name $DOMAIN;
 
     access_log off;
 
@@ -56,10 +56,10 @@ server {
     listen 443 ssl;
     listen [::]:443 ssl;
 
-    server_name nyrkio.com;
+    server_name $DOMAIN;
 
-    ssl_certificate /etc/nginx/ssl/live/nyrkio.com/fullchain.pem;
-    ssl_certificate_key /etc/nginx/ssl/live/nyrkio.com/privkey.pem;
+    ssl_certificate /etc/nginx/ssl/live/$DOMAIN/fullchain.pem;
+    ssl_certificate_key /etc/nginx/ssl/live/$DOMAIN/privkey.pem;
 
     location /p/ {
         proxy_pass http://51.20.96.129/;


### PR DESCRIPTION
It's unclear why these reverted commits were needed in the first place. Most likely due to some difference in the way that me and @henrikingo were deploying things.