### PR TITLE
Fix: pymongo error "An empty update path is not valid."

### DIFF
--- a/backend/api/background.py
+++ b/backend/api/background.py
@@ -113,7 +113,11 @@ async def precompute_summaries_non_leaf(user_or_org_id):
         for k in cache.keys():
             if k == "_id":
                 continue
-            if test_name_prefix in k and k != test_name_prefix:
+            if (
+                test_name_prefix in k
+                and k != test_name_prefix
+                and test_name_prefix != ""
+            ):
                 prefix_leaves.append(k)
         leaf_summaries = [cache[leaf] for leaf in prefix_leaves]
         for leaf_summary in leaf_summaries:


### PR DESCRIPTION
This happened for for summaries because we use the test_name path as the key in the summaries_cache dict/json. The root of the hierarchy, ie the summary of all your tests, would have a path of the empty string. This is not allowed by pymongo.

Fix is to skip computing the root / empty string as key. We don't need it.