### PR TITLE
Add /admin/impersonate API and related frontend

### DIFF
--- a/backend/api/admin.py
+++ b/backend/api/admin.py
@@ -1,13 +1,31 @@
 import logging
 from typing import Dict, List
+from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi_users.exceptions import UserNotExists
 
 from backend.auth import auth
 from backend.db.db import User, DBStore
+from backend.auth.superuser import superuser_active_map
+
+from pydantic import BaseModel
 
 admin_router = APIRouter(prefix="/admin")
+
+
+@admin_router.get("/all_users")
+async def all_users(user: User = Depends(auth.current_active_superuser)) -> List[Dict]:
+    logging.info(f"Admin {user.email} requested all users")
+    store = DBStore()
+    results = await store.get_all_users()
+    return results
+
+
+class ImpersonateLogin(BaseModel):
+    username: str
+    # Not actually used:
+    id: str
 
 
 @admin_router.get("/results")
@@ -51,8 +69,71 @@ async def get_result(
         user = await auth.get_user_by_email(user_email)
     except UserNotExists:
         raise HTTPException(status_code=404, detail="No such user exists")
-
     store = DBStore()
     test_name = "/".join(test_path.split("/")[1:])
     results, _ = await store.get_results(user.id, test_name)
     return results
+
+
+@admin_router.post("/impersonate")
+async def impersonate(
+    data: ImpersonateLogin, user: User = Depends(auth.current_active_superuser)
+) -> Dict:
+    logging.info(f"Admin {user.email} requested to impersonate {data.username}")
+    fa_user = await auth.get_user_by_email(data.username)
+    if not str(fa_user.id) == data.id:
+        print(fa_user)
+        raise ValueError(
+            "id fields for the user you asked to impersonate doesn't match. ({} {})".format(
+                data.username, data.id
+            )
+        )
+
+    datetime.now(timezone.utc) + timedelta(seconds=2 * 3600)
+
+    # store = DBStore()
+    # await store.set_impersonate_user(admin_user=user, impersonate_user=fa_user, expire=expire)
+    superuser_active_map[user.email] = fa_user
+    return_user = {
+        "user_id": str(fa_user.id),
+        "user_email": data.username,
+        "superuser": {"user_email": user.email},
+    }
+
+    return return_user
+
+
+@admin_router.get("/impersonate")
+async def impersonate_get(user: User = Depends(auth.current_active_user)) -> Dict:
+    # store = DBStore()
+    # await store.get_impersonate_user(admin_user=user)
+    return_user = {
+        "user_id": str(user.id),
+        "user_email": user.email,
+    }
+    if user.superuser and "user_email" in user.superuser:
+        return_user["superuser"] = {
+            "user_email": user.superuser["user_email"],
+        }
+    return return_user
+
+
+@admin_router.delete("/impersonate")
+async def impersonate_delete(user: User = Depends(auth.current_active_user)) -> Dict:
+    if (
+        user
+        and user.superuser
+        and "user_email" in user.superuser
+        and user.superuser["user_email"] in superuser_active_map
+    ):
+        del superuser_active_map[user.superuser["user_email"]]
+        # store = DBStore()
+        # await store.delete_impersonate_user(admin_user=user, impersonate_user=fa_user, expire=expire)
+    return_user = {}
+    if user.superuser and "user_email" in user.superuser:
+        return_user = {
+            "user_email": user.superuser["user_email"],
+            "yourself": True,
+        }
+
+    return return_user

--- a/backend/api/api.py
+++ b/backend/api/api.py
@@ -23,7 +23,6 @@ from backend.db.db import (
 from backend.notifiers.slack import SlackNotifier
 from backend.api.background import precompute_cached_change_points
 
-
 app = FastAPI(openapi_url="/openapi.json")
 
 

--- a/backend/auth/auth.py
+++ b/backend/auth/auth.py
@@ -38,6 +38,7 @@ from backend.db.db import (
 )
 from backend.auth.github import github_oauth
 from backend.auth.email import send_email, read_template_file
+from backend.auth.superuser import SuperuserStrategy
 
 
 async def get_user_manager(user_db: BeanieUserDatabase = Depends(get_user_db)):
@@ -68,8 +69,20 @@ cookie_backend = AuthenticationBackend(
     get_strategy=get_jwt_strategy,
 )
 
+
+def get_superuser_strategy() -> SuperuserStrategy:
+    return SuperuserStrategy(secret=SECRET, lifetime_seconds=None)
+
+
+superuser_backend = AuthenticationBackend(
+    name="jwt",  # superuser strategy extends jwt
+    transport=bearer_transport,
+    get_strategy=get_superuser_strategy,
+)
+
+
 fastapi_users = FastAPIUsers[User, uuid.UUID](
-    get_user_manager, [jwt_backend, cookie_backend]
+    get_user_manager, [superuser_backend, cookie_backend]
 )
 
 # Github requires this to be the exact same string, so no use trying to switch between

--- a/backend/auth/superuser.py
+++ b/backend/auth/superuser.py
@@ -1,0 +1,46 @@
+from typing import Optional
+
+from fastapi_users import BaseUserManager, models, exceptions
+from fastapi_users.authentication.strategy import JWTStrategy
+
+
+# Originally stored in Mongodb, but this is quite a frequent call
+# FIXME: Will break on multiple backend nodes
+superuser_active_map = {}
+
+
+class SuperuserStrategy(JWTStrategy):
+    def __init__(
+        self,
+        lifetime_seconds: Optional[int],
+        secret: str = "qwerty",
+    ):
+        super().__init__(lifetime_seconds=lifetime_seconds, secret=secret)
+
+    async def read_token(
+        self, token: Optional[str], user_manager: BaseUserManager[models.UP, models.ID]
+    ) -> Optional[models.UP]:
+        admin_user = await super().read_token(token, user_manager)
+        if admin_user is None:
+            return None
+
+        if not admin_user.is_superuser:
+            return admin_user
+
+        user = superuser_active_map.get(admin_user.email)
+        if not user:
+            return admin_user
+        try:
+            impersonate_user = await user_manager.get(user.id)
+            impersonate_user.superuser = {"user_email": admin_user.email}
+            return impersonate_user
+        except exceptions.InvalidID:
+            print("superuser: InvalidID")
+            return admin_user
+        except exceptions.UserNotExists:
+            print("superuser: UserNotExists")
+            return admin_user
+
+    async def destroy_token(self, admin_user: str, user: models.UP) -> None:
+        # await self.store.delete_impersonate_user(token)
+        del superuser_active_map[admin_user]

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -103,6 +103,14 @@ def client():
 
 
 @pytest.fixture
+def superuser_client():
+    with SuperuserClient(app) as client:
+        yield client
+        # Delete all results after each test
+        client.delete("/api/v0/results")
+
+
+@pytest.fixture
 def unauthenticated_client():
     with TestClient(app) as client:
         yield client

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -1,0 +1,44 @@
+import json
+
+
+def test_impersonate_other_user(superuser_client):
+    superuser_client.login()
+
+    response = superuser_client.get("/api/v0/admin/impersonate")
+    response.raise_for_status()
+    data = response.json()
+    print(data)
+    assert data["user_email"] == "admin@foo.com"
+    assert "superuser" not in data
+
+    user_id = "Need to find this out it changes every time"
+    response = superuser_client.get("/api/v0/admin/all_users")
+    response.raise_for_status()
+    data = response.json()
+    print(data)
+    for u in data:
+        if u["email"] == "john@foo.com":
+            user_id = u["_id"]
+
+    response = superuser_client.post(
+        "/api/v0/admin/impersonate",
+        data=json.dumps({"username": "john@foo.com", "id": user_id}),
+    )
+
+    data = response.json()
+    print(data)
+    response.raise_for_status()
+    assert data["user_email"] == "john@foo.com"
+    assert data["superuser"]["user_email"] == "admin@foo.com"
+
+    response = superuser_client.get("/api/v0/admin/impersonate")
+    response.raise_for_status()
+    data = response.json()
+    assert data["user_email"] == "john@foo.com"
+    assert data["superuser"]["user_email"] == "admin@foo.com"
+
+    response = superuser_client.delete("/api/v0/admin/impersonate")
+    response.raise_for_status()
+    data = response.json()
+    assert data["user_email"] == "admin@foo.com"
+    assert data["yourself"] is True

--- a/backend/tests/test_core.py
+++ b/backend/tests/test_core.py
@@ -184,6 +184,10 @@ def test_tigerbeetle_data(shared_datadir):
 
     assert len(changes) == 1
     assert "tigerbeetle" in changes
+    res = vars(series.results)["_lists"][0]
+    met = [x.__dict__["metrics"] for x in res]
+    print([x[0].__dict__["value"] for x in met])
+    print(changes)
     assert len(changes["tigerbeetle"]) == 2
 
     expected_commits = (

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,6 +4,8 @@ services:
   mongodb:
     container_name: mongodb
     image: mongodb/mongodb-community-server:latest
+    environment:
+      - API_PORT=27017
     ports:
       - "27017:27017"
     command: mongod --quiet --logpath /dev/null

--- a/frontend/src/components/AdminDashboard.jsx
+++ b/frontend/src/components/AdminDashboard.jsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { SingleResultWithTestname } from "./Dashboard";
+import { impersonateUser } from "./ImpersonateControls";
 
 const UserResults = ({ user, testNames, embed }) => {
-  console.log("testname");
-  console.log(testNames);
+  console.debug("testname");
+  console.debug(testNames);
 
   if (
     testNames === undefined ||
@@ -20,7 +21,7 @@ const UserResults = ({ user, testNames, embed }) => {
       <ul>
         {testNames.map((testName) => {
           return Object.values(testName).map((testName) => {
-            console.log(testName);
+            console.debug(testName);
             if (testName === undefined || testName.length === 0) {
               return <></>;
             }
@@ -45,16 +46,17 @@ const UserResults = ({ user, testNames, embed }) => {
     </div>
   );
 };
+
 const UserTable = ({ data }) => {
   console.log("data is");
   console.log(data);
   return (
     <div className="row">
       <ul>
-        {Object.entries(data).map(([user, testName]) => {
+        {Object.entries(data).map(([idx, user]) => {
           return (
-            <li className="list-group-item">
-              <Link to={`/admin/tests/${user}`}>{user}</Link>
+            <li className="list-group-item" key={user['_id'] || -1}>
+              <Link to={`/`} onClick={(event) => {event.preventDefault(); impersonateUser(user).then(()=>{ window.location.href = '/'})}}>{user['email']}</Link>
             </li>
           );
         })}
@@ -70,7 +72,7 @@ const MainAdminDashboard = ({ results }) => {
         <h1>Admin Dashboard</h1>
         <div>
           <div className="card">
-            <div className="card-header">All user tests</div>
+            <div className="card-header">Impersonate user:</div>
             <div className="card-body">
               <ul className="list-group list-group-flush">
                 <UserTable data={results} />
@@ -93,14 +95,14 @@ export const AdminDashboard = () => {
   const [loading, setLoading] = useState(false);
   const [results, setResults] = useState([{}]);
   const fetchData = async () => {
-    const results = await fetch("/api/v0/admin/results", {
+    const tempresults = await fetch("/api/v0/admin/all_users", {
       headers: {
         "Content-type": "application/json",
         Authorization: "Bearer " + localStorage.getItem("token"),
       },
     });
-    const resultData = await results.json();
-    console.log(resultData);
+    const resultData = await tempresults.json();
+    console.debug(resultData);
     setResults(resultData);
   };
 
@@ -110,19 +112,11 @@ export const AdminDashboard = () => {
       setLoading(false);
     });
   }, []);
-
   if (loading) {
     return <div>Loading...</div>;
-  }
-
-  if (location.pathname.startsWith("/admin/tests")) {
-    const user = location.pathname.split("/")[3];
-    return (
-      <>
-        <AdminUserResults user={user} results={results} />
-      </>
-    );
-  } else {
-    return <MainAdminDashboard results={results} />;
-  }
+ }
+ return <MainAdminDashboard results={results} />;
 };
+
+
+

--- a/frontend/src/components/ImpersonateControls.jsx
+++ b/frontend/src/components/ImpersonateControls.jsx
@@ -1,0 +1,118 @@
+import { useState, useEffect } from "react";
+import { Link, useLocation } from "react-router-dom";
+
+import Button from 'react-bootstrap/Button';
+
+
+export const ImpersonateControls = () => {
+  const [whoami , setWhoami] = useState({});
+
+  useEffect(() => {
+    getImpersonateUser().then((impersonate_user) => {
+      setWhoami( impersonate_user || {});
+    });
+  }, []);
+
+
+  const ActualImpersonateControls = ({whoami}) => {
+    const stopIt = () => {
+        stopImpersonateUser().then( (original_user) => {
+            setWhoami(original_user);
+            window.location.reload(true);
+        });
+    };
+
+  if (whoami && "superuser" in whoami && "user_email" in whoami) {
+    let admin_user = whoami.superuser.user_email;
+    let titlemsg = "You are an administrator that has assumed the role of another user. Click here to return to your normal user account: " + admin_user;
+  return (
+    <>
+    <Button href="/admin" className="btn btn-danger" onClick={(event) => { event.preventDefault(); stopIt();}}
+    title={titlemsg}
+    >  &#x2716; </Button>
+    </>
+
+  );
+   }
+   else {
+     return "";
+   }
+  };
+
+  return <ActualImpersonateControls whoami={whoami} />;
+};
+
+
+export const impersonateUser = async (impersonate_user) => {
+  const fetchData = async () => {
+    const body = {
+          username: impersonate_user['email'],
+          id: impersonate_user['_id'],
+    };
+    const results = await fetch("/api/v0/admin/impersonate", {
+      method: "POST",
+      headers: {
+        "Content-type": "application/json",
+        Authorization: "Bearer " + localStorage.getItem("token"),
+      },
+      body: JSON.stringify(body),
+    });
+    const resultData = await results.json();
+    console.debug(resultData);
+    if("superuser" in resultData){
+      localStorage.setItem("username", resultData['user_email']);
+      document.body.classList.add( "impersonate-user" );
+    }
+
+    return resultData;
+  };
+  return await fetchData();
+
+};
+
+const getImpersonateUser = async () => {
+  const fetchData = async () => {
+    const results = await fetch("/api/v0/admin/impersonate", {
+      method: "GET",
+      headers: {
+        "Content-type": "application/json",
+        Authorization: "Bearer " + localStorage.getItem("token"),
+      },
+    });
+    const resultData = await results.json();
+    console.debug(resultData);
+    if(resultData && 'user_email' in resultData) {
+      localStorage.setItem("username", resultData['user_email']);
+    }
+    if(resultData && 'superuser' in resultData) {
+      document.body.classList.add( "impersonate-user" );
+    }
+    else {
+      document.body.classList.remove( "impersonate-user" );
+    }
+    return resultData;
+  };
+  return await fetchData();
+
+};
+
+const stopImpersonateUser = async () => {
+  console.log("stopping");
+  const fetchData = async () => {
+    console.log("stopping fetchdata");
+    const results = await fetch("/api/v0/admin/impersonate", {
+      method: "DELETE",
+      headers: {
+        "Content-type": "application/json",
+        Authorization: "Bearer " + localStorage.getItem("token"),
+      },
+    });
+    const resultData = await results.json();
+    console.debug(resultData);
+    localStorage.setItem("username", localStorage.getItem("username_real"))
+    document.body.classList.remove( "impersonate-user" );
+    return resultData;
+  };
+  return await fetchData();
+
+};

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -58,6 +58,9 @@ export const Login = ({ loggedIn, setLoggedIn }) => {
       })
       .then((body) => {
         if (!body) {
+          console.log("Empty response when logging in.")
+          setErrorText("Empty response when logging in.");
+          setLoggedIn(false);
           return;
         }
         console.log("Logged in. (" + username + ")");
@@ -66,6 +69,7 @@ export const Login = ({ loggedIn, setLoggedIn }) => {
 
         localStorage.setItem("loggedIn", "true");
         localStorage.setItem("username", username);
+        localStorage.setItem("username_real", username);
         localStorage.setItem("token", body["access_token"]);
         localStorage.setItem("authMethod", "password");
         localStorage.setItem("authServer", "nyrkio.com");
@@ -182,12 +186,24 @@ export const Login = ({ loggedIn, setLoggedIn }) => {
   );
 };
 
-export const LogOut = ({ setLoggedIn }) => {
-  const handleLogoutClick = () => {
+const logoutTasks = ({setLoggedIn}) => {
+
     console.log("Setting logged in to false");
     setLoggedIn(false);
+
     localStorage.setItem("loggedIn", "false");
+    localStorage.setItem("username", "");
+    localStorage.setItem("username_real", "");
+    document.body.classList.remove( "impersonate-user" );
+
+
     posthog.reset();
+
+};
+
+export const LogOut = ({ setLoggedIn }) => {
+  const handleLogoutClick = () => {
+    logoutTasks({setLoggedIn});
   };
   return (
     <>

--- a/frontend/src/components/Nav.jsx
+++ b/frontend/src/components/Nav.jsx
@@ -1,6 +1,7 @@
 import { LogOut, LoginButton } from "./Login.jsx";
 import { UserMenu } from "./UserMenu.jsx";
 import { SmallLogo } from "./Logo";
+import { ImpersonateControls } from "./ImpersonateControls";
 
 const NavigationItems = () => {
   return (
@@ -65,13 +66,15 @@ export const NavHeader = ({ loggedIn, setLoggedIn }) => {
       <div className="container-fluid m-1">
         <NavigationItems />
         {loggedIn ? (
-          <>
             <UserMenu setLoggedIn={setLoggedIn} />
-          </>
         ) : (
           <LoginButton />
         )}
+        <div className=" nyrkio-login-controls">
+        <ImpersonateControls />
+        </div>
       </div>
     </nav>
   );
 };
+

--- a/frontend/src/components/UserMenu.jsx
+++ b/frontend/src/components/UserMenu.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import "bootstrap-icons/font/bootstrap-icons.css";
 import Dropdown from "react-bootstrap/Dropdown";
+import { ImpersonateControls } from "./ImpersonateControls";
 
 export const UserMenu = ({ setLoggedIn }) => {
   const [isAdmin, setIsAdmin] = useState(false);
@@ -8,7 +9,8 @@ export const UserMenu = ({ setLoggedIn }) => {
   if (localStorage.getItem("loggedIn") == "true") {
     username = localStorage.getItem("username");
   }
-
+  console.debug("username");
+  console.debug(username);
   const checkForAdminPrvis = async () => {
     const response = await fetch("/api/v0/auth/admin", {
       method: "GET",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -395,6 +395,25 @@ button:focus-visible {
   box-shadow: none;
 }
 
+.btn-danger {
+  color: white;
+  background-color: var(--nyrkio-dark-gray);
+  border-color: var(--nyrkio-dark-gray);
+  box-shadow: none;
+}
+body.impersonate-user nav.navbar-top .btn-success,
+body.impersonate-user nav.navbar-top .btn-danger {
+  border-radius: 0;
+}
+
+body.impersonate-user {
+  border: 5px solid orangered;
+}
+
+body.impersonate-user nav.navbar-top {
+  background-color: orangered;
+}
+
 .btn-check:focus + .btn-success,
 .btn-success:focus {
   color: var(--nyrkio-light-gray3);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -8,8 +8,8 @@ export default defineConfig({
   server: {
     proxy: {
       "/api": {
-        target: "https://nyrk.io",
-        // target: "http://localhost",
+        // target: "https://nyrk.io",
+        target: "http://localhost",
         changeOrigin: true,
         // rewrite: (path) => path.replace(/^\/api/, ""),
       },


### PR DESCRIPTION
A superuser can assume the identity of any other user. You continue to use your JWT token. The Fastapi authentication layer overrides this so you become the other user in the backend. In the frontend localStorage('username') is set to the impersonated value and localStorage('username_real') is the original, actual identity. Note that the JWT token also includes your actual identity, and this is the only thing sent to the backend.

In the frontend orangered CSS is used to bring attention to the fact you are now using another users credentials.