### PR TITLE
backend/api: Lookup org notifiers for /changes API

### DIFF
--- a/backend/api/api.py
+++ b/backend/api/api.py
@@ -63,7 +63,7 @@ async def changes(
 ):
     store = DBStore()
     config, config_meta = await store.get_user_config(user.id)
-    notifiers = await _get_notifiers(notify, config, user)
+    notifiers = await get_notifiers(notify, config, user)
     return await calc_changes(test_name, user.id, notifiers)
 
 
@@ -232,7 +232,7 @@ async def do_db():
     await do_on_startup()
 
 
-async def _get_notifiers(notify: Union[int, None], config: dict, user: User) -> list:
+async def get_notifiers(notify: Union[int, None], config: dict, user: User) -> list:
     notifiers = []
     if notify:
         slack = config.get("slack", {})

--- a/backend/api/organization.py
+++ b/backend/api/organization.py
@@ -49,7 +49,11 @@ def get_org_with_raise(orgs, org_string):
 
 
 @org_router.get("/result/{test_name:path}/changes")
-async def changes(test_name: str, user: User = Depends(auth.current_active_user)):
+async def changes(
+    test_name: str,
+    notify: Union[int, None] = None,
+    user: User = Depends(auth.current_active_user),
+):
     user_orgs = get_user_orgs(user)
     org = get_org_with_raise(user_orgs, test_name.split("/")[0])
 
@@ -63,9 +67,10 @@ async def changes(test_name: str, user: User = Depends(auth.current_active_user)
     if core_config:
         core_config = Config(**core_config)
 
-    from backend.api.api import calc_changes
+    from backend.api.api import calc_changes, get_notifiers
 
-    return await calc_changes(test_name, org["id"])
+    notifiers = await get_notifiers(notify, config, user)
+    return await calc_changes(test_name, org["id"], notifiers)
 
 
 @org_router.get("/result/{test_name_prefix:path}/summary")


### PR DESCRIPTION
Just like the user /changes API, orgs might want to trigger notifications too.

Long term, we should refactor these two code paths (orgs and users) so that they share all this code.