### PR TITLE
frontend: Show all graphs as a flat list

### DIFF
--- a/frontend/src/components/ChangePointSummaryTable.jsx
+++ b/frontend/src/components/ChangePointSummaryTable.jsx
@@ -11,7 +11,7 @@ const Loading = ({loading}) => {
   return (<><div className="loading_done"></div></>);
 };
 
-export const ChangePointSummaryTable = ({ changeData, queryStringTextTimestamp, loading }) => {
+export const ChangePointSummaryTable = ({ title, changeData, queryStringTextTimestamp, loading }) => {
   var rowData = [];
 
   console.debug(changeData);
@@ -95,7 +95,7 @@ export const ChangePointSummaryTable = ({ changeData, queryStringTextTimestamp, 
   return (
     <>
       <div className="row text-center">
-        <h3>Performance Changes</h3>
+        <h3>{title?title:"Performance Changes"}</h3>
       </div>
       <div
         className="ag-theme-quartz ag-theme-nyrkio pb-5"

--- a/frontend/src/components/FrontPage.jsx
+++ b/frontend/src/components/FrontPage.jsx
@@ -10,13 +10,16 @@ const Banner = () => {
     <div className="container-fluid text-center nyrkio-title">
       <Logo color="Brown" filetype="png" />
       <h1>For Faster Software</h1>
-      <h5>Harness the power of change point detection</h5>
     </div>
   );
 };
 
 const FeatureHighlight = () => {
   return (
+    <>
+    <div className="text-center">
+      <h2>Harness the power of change point detection</h2>
+    </div>
     <div className="row row-cols-lg-3 row-cols-1 frontpage-triplet text-center m-5">
       <div className="col">
         <h3>Shift left</h3>
@@ -46,6 +49,7 @@ const FeatureHighlight = () => {
         </p>
       </div>
     </div>
+    </>
   );
 };
 

--- a/frontend/src/components/TableOrResult.jsx
+++ b/frontend/src/components/TableOrResult.jsx
@@ -20,9 +20,9 @@ export const TableOrResult = ({ prefix, data, baseUrls, dashboardType, embed, lo
   const shortNames = createShortNames(prefix, testNames);
   const displayNames = shortNames.map((name)=>decodeURIComponent(name));
 
-  console.debug(singleTestName);
-  console.debug(prefix);
-  console.debug(data);
+//   console.debug(singleTestName);
+//   console.debug(prefix);
+//   console.debug(data);
 
   // If we found an exact match, display the result
   if (data.includes(prefix) || singleTestName) {
@@ -57,12 +57,14 @@ export const TableOrResult = ({ prefix, data, baseUrls, dashboardType, embed, lo
             shortNames={shortNames}
             displayNames={displayNames}
             prefix={prefix}
+            dashboardType={dashboardType}
+            embed={embed}
 
             loading={loading}
             setLoading={setLoading}
-          setSummaries={setSummaries}
-          summaries={summaries}
-          />
+            setSummaries={setSummaries}
+            summaries={summaries}
+            />
       </>
     );
   }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -212,7 +212,7 @@ h1,
 }
 h2,
 .h2 {
-  letter-spacing: 0.05rem;
+  letter-spacing: 0.1rem;
 }
 h3,
 .h3 {
@@ -243,6 +243,10 @@ h6,
 h1,
 .h1 {
   font-size: calc(1.425rem + 2.1vw);
+}
+h2,
+.h2 {
+  font-size: calc(1rem + 2.1vw);
 }
 h1,
 .h1,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -412,6 +412,39 @@ button:focus-visible {
   margin: 10px;
 }
 
+.btn-secondary:focus,
+.btn-secondary {
+  color: var(--nyrkio-light-gray3);
+  background-color: var(--nyrkio-active);
+  border-color: var(--nyrkio-dark-gray);
+  max-height: 2.5em;
+  padding-top: 5px;
+  box-shadow: none;
+}
+.btn-secondary:focus:hover,
+.btn-secondary:hover {
+  background-color: var(--nyrkio-horn-dark-brown);
+  border-color: var(--nyrkio-dark-gray);
+  box-shadow: none;
+}
+
+.btn-nothing:focus,
+.btn-nothing {
+  color: var(--nyrkio-arrow-brown);
+  border-color: none;
+  max-height: 2.5em;
+  padding-top: 5px;
+  box-shadow: none;
+  box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
+}
+#allGraphsButton[aria-expanded=true],
+.btn-nothing:focus:hover,
+.btn-nothing:hover {
+  color: var(--nyrkio-bear-brown);
+  border-color: var(--nyrkio-dark-gray);
+  background-color: none;
+}
+
 .btn-danger {
   color: white;
   background-color: var(--nyrkio-dark-gray);
@@ -542,13 +575,19 @@ ol.breadcrumb {
   border: none;
 }
 
+div.card div.card-header-selector,
 div.card div.card-header:first-child,
 div.card div.card-header {
   color: var(--bs-heading-color);
-  background-color: var(--nyrkio-active);
-  border-color: 1px solid var(--nyrkio-border);
+  background-color: var(--nyrkio-light-gray);
+  border-color: 1px solid var(--nyrkio-dark-gray);
   border-radius: 7px;
   font-size: 105%;
+}
+#dashboard_settings div.card div.card-header {
+  color: var(--bs-heading-color);
+  background-color: var(--nyrkio-dark-gray);
+  border-color: 1px solid var(--nyrkio-dark-gray);
 }
 
 .list-group .list-group-item {
@@ -907,22 +946,28 @@ div.card.people-card .card-header img {
 }
 
 #dashboard_settings .inactive-label {
-  color: var(--nyrkio-dark-gray);
+  color: var(--nyrkio-horn-dark-brown);
   position: absolute;
-  top: -2rem;
-  right: 1.5rem;
+  top: 0rem;
+  right: 3.5rem;
   width: 25rem;
   text-align: right;
-  transition: 2s;
+  transition: 5s;
+  opacity:0;
 }
 
+#dashboard_settings:hover .inactive-label {
+  transition: 0.2s;
+  opacity:1;
+}
 #dashboard_settings .btn[aria-expanded=true]  .inactive-label {
     opacity: 0;
     transition: 2s;
+    shadow: darkgreen;
 }
 
 #dashboard_settings #linkToGraphs a {
-    color: var(--nyrkio-dark-gray);
+    color: var(--nyrkio-light-gray);
 }
 #dashboard_settings #linkToGraphs {
     background-color: var(--nyrkio-horn-light-brown);
@@ -932,23 +977,26 @@ div.card.people-card .card-header img {
 }
 
 #dashboard_settings #dashboardSettingsButton.btn {
-    background-color: var(--nyrkio-horn-light-brown);
-    color: white;
+    color: var(--nyrkio-bear-brown);
+    border-color: var(--nyrkio-dark-gray);
+    background-color: var(--nyrkio-light-gray);
     margin: 0px;
     z-index: 10;
     position: relative;
     right: 1rem;
+    box-shadow: none;
 }
 
 #dashboard_settings #dashboardSettingsButton.btn.show {
-    background-color: var(--nyrkio-horn-light-brown);
-    color: white;
+    border-color: var(--nyrkio-dark-gray);
     z-index: 10;
 }
 #dashboard_settings #dashboardSettingsButton.btn[aria-expanded=true] {
-    background-color: var(--nyrkio-horn-light-brown);
-    color: white;
+    color: var(--nyrkio-bear-brown);
+    background-color: var(--nyrkio-light-gray);
+    border-color: var(--nyrkio-dark-gray);
     z-index: 10;
+    box-shadow: none;
 }
 
 #dashboard_settings .card,


### PR DESCRIPTION
User option, stored in localStorage, to show all graphs in the subtree immediately. Limited to 30 graphs. If subtree is larger, button is hidden.

Also worked on more consistency in the various brown colors.