### PR TITLE
pulls/ fixes

### DIFF
--- a/backend/api/public.py
+++ b/backend/api/public.py
@@ -168,9 +168,12 @@ async def get_pr_changes(
     pull_number: int,
     git_commit: str,
 ):
-    user_or_org_id, _ = await _figure_out_user_and_test(test_name)
     return await _get_pr_changes(
-        pull_number, git_commit, repo, notify=None, user_or_org_id=user_or_org_id
+        pull_number=pull_number,
+        git_commit=git_commit,
+        repo=repo,
+        test_name=test_name,
+        notify=None,
     )
 
 

--- a/backend/db/db.py
+++ b/backend/db/db.py
@@ -550,11 +550,16 @@ class DBStore(object):
             results = (
                 await test_results.find(
                     {
-                        "user_id": id,
-                        "test_name": test_name,
                         "$or": [
-                            {"pull_request": {"$eq": pull_request}},
-                            {"pull_request": {"$exists": False}},
+                            {
+                                "test_name": test_name,
+                                "pull_request": {"$eq": pull_request},
+                            },
+                            {
+                                "user_id": id,
+                                "test_name": test_name,
+                                "pull_request": {"$exists": False},
+                            },
                         ],
                     },
                     exclude_projection,
@@ -1179,6 +1184,7 @@ class DBStore(object):
             },
             {
                 "$project": {
+                    "_id": False,
                     "git_repo": "$_id.git_repo",
                     "branch": "$_id.branch",
                     "git_commit": "$_id.git_commit",
@@ -1191,7 +1197,7 @@ class DBStore(object):
         ]
         print(pipeline)
         pulls = await coll.aggregate(pipeline).to_list(None)
-
+        print(pulls)
         return pulls
 
     async def get_pull_requests(

--- a/backend/tests/test_api_pulls.py
+++ b/backend/tests/test_api_pulls.py
@@ -38,7 +38,8 @@ def test_pr_add_result(client):
             "pull_number": pull_number,
             "test_names": benchmark_names,
             "git_commit": "12345",
-            "git_repo": repo,
+            "git_repo": "https://github.com/" + repo,
+            "branch": "main",
         }
     ]
 
@@ -348,13 +349,15 @@ def test_pr_pulls(client):
     response = client.get("/api/v0/pulls")
     assert response.status_code == 200
     json = response.json()
+    print(json)
     assert len(json) == 1
     assert json == [
         {
             "pull_number": pull_number,
             "test_names": [test_name],
             "git_commit": git_commit,
-            "git_repo": repo,
+            "git_repo": "https://github.com/" + repo,
+            "branch": "main",
         }
     ]
 
@@ -468,7 +471,9 @@ def test_only_last_pr_result_used_in_changes(client):
     )
     assert response.status_code == 200
 
-    response = client.get(f"/api/v0/pulls/{repo}/{pull_number}/changes/{git_commit}")
+    response = client.get(
+        f"/api/v0/pulls/{repo}/{pull_number}/changes/{git_commit}/test/{test_name}"
+    )
     assert response.status_code == 200
     json = response.json()
     assert len(json) == 1

--- a/frontend/src/components/PullRequest.jsx
+++ b/frontend/src/components/PullRequest.jsx
@@ -29,7 +29,7 @@ export const Pulls = ({testName, sendSelectedPr, baseUrls, breadcrumbName, dashb
       url = `${baseUrls.apiRoot}${orgEtcPrefix}/pulls`;
     }
     if(dashboardType == dashboardTypes.PUBLIC) {
-      var url = `${baseUrls.apiRoot}pulls/${testName}`;
+      url = `${baseUrls.apiRoot}pulls/${testName}`;
     }
       console.log(url);
     const response = await fetch(url, {
@@ -51,7 +51,8 @@ export const Pulls = ({testName, sendSelectedPr, baseUrls, breadcrumbName, dashb
     for (var o of res) {
       for (var name of o.test_names){
         if (orgRepoBranch + name === testName){
-          const key = `${o.git_repo}/pull/${o.pull_number}`;
+          var git_repo = o.git_repo.replace("https://github.com/", "");
+          const key = `${git_repo}/pull/${o.pull_number}`;
           if (commits[key] === undefined) {
             commits[key] = [];
             filteredPullRequests.push(key);
@@ -65,7 +66,7 @@ export const Pulls = ({testName, sendSelectedPr, baseUrls, breadcrumbName, dashb
 
   const fetchPullResult = async (pr, c) => {
     const [repo, pull_number] = pr.split("/pull/");
-    const url = `${baseUrls.apiRoot}pulls/${repo}/${pull_number}/result/${c}/test/${testName}`
+    var url = `${baseUrls.apiRoot}pulls/${repo}/${pull_number}/result/${c}/test/${testName}`
     const response = await fetch(url, {
       headers: {
         "Content-type": "application/json",
@@ -82,7 +83,15 @@ export const Pulls = ({testName, sendSelectedPr, baseUrls, breadcrumbName, dashb
     const res = await response.json();
     console.log(res);
 
-    const response2 = await fetch(`${baseUrls.apiRoot}pulls/${repo}/${pull_number}/changes/${c}`, {
+    url = `${baseUrls.apiRoot}pulls/${repo}/${pull_number}/changes/${c}`;
+    if(dashboardType == dashboardTypes.ORG) {
+      url = `${baseUrls.apiRoot}pulls/${repo}/${pull_number}/changes/${c}`;
+    }
+    if(dashboardType == dashboardTypes.PUBLIC) {
+      // From backend: "/pulls/{repo:path}/{pull_number}/changes/{git_commit}/test/{test_name:path}"
+      url = `${baseUrls.apiRoot}pulls/${repo}/${pull_number}/changes/${c}/test/${testName}`;
+    }
+    const response2 = await fetch(url, {
       headers: {
         "Content-type": "application/json",
         Authorization: "Bearer " + localStorage.getItem("token"),


### PR DESCRIPTION
Introduce new get_pulls_from_the_source() which uses aggregation query directly on test_results. Avoids separate collection + python code.

Small API breakage: add branch both as parameter and in result

And of course don't use user_id for PR

5 new test failures as MongoMock doesn't support aggregation. Failures look like

ValueError: too many values to unpack (expected 2)