### PR TITLE
docker: Split backend into two containers, use second for webhooks

### DIFF
--- a/.github/workflows/deploy-prod-really.yml
+++ b/.github/workflows/deploy-prod-really.yml
@@ -55,4 +55,4 @@ jobs:
           docker context create $ENV --docker "host=ssh://$SSH_USER@nyrkio.com"
           docker context use $ENV
 
-          docker --context $ENV compose -f docker-compose.yml up --no-build -d nginx backend
+          docker --context $ENV compose -f docker-compose.yml up --no-build -d nginx backend webhooks

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -60,6 +60,7 @@ jobs:
           echo "Pushing image to ECR..."
           docker push $ECR_REGISTRY/nyrkio/prod/nginx:$IMAGE_TAG
           docker push $ECR_REGISTRY/nyrkio/prod/backend:$IMAGE_TAG
+          docker push $ECR_REGISTRY/nyrkio/prod/webhooks:$IMAGE_TAG
           echo "image=$ECR_REGISTRY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
   deployment:
@@ -114,4 +115,4 @@ jobs:
           docker context create $ENV --docker "host=ssh://$SSH_USER@nyrkio.com"
           docker context use $ENV
 
-          docker --context $ENV compose -f docker-compose.yml up --no-build -d nginx backend
+          docker --context $ENV compose -f docker-compose.yml up --no-build -d nginx backend webhooks

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -60,7 +60,6 @@ jobs:
           echo "Pushing image to ECR..."
           docker push $ECR_REGISTRY/nyrkio/prod/nginx:$IMAGE_TAG
           docker push $ECR_REGISTRY/nyrkio/prod/backend:$IMAGE_TAG
-          docker push $ECR_REGISTRY/nyrkio/prod/webhooks:$IMAGE_TAG
           echo "image=$ECR_REGISTRY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
   deployment:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -58,7 +58,6 @@ jobs:
           echo "Pushing image to ECR..."
           docker push $ECR_REGISTRY/nyrkio/staging/nginx:$IMAGE_TAG
           docker push $ECR_REGISTRY/nyrkio/staging/backend:$IMAGE_TAG
-          docker push $ECR_REGISTRY/nyrkio/staging/webhooks:$IMAGE_TAG
           echo "image=$ECR_REGISTRY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
   deployment:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -58,6 +58,7 @@ jobs:
           echo "Pushing image to ECR..."
           docker push $ECR_REGISTRY/nyrkio/staging/nginx:$IMAGE_TAG
           docker push $ECR_REGISTRY/nyrkio/staging/backend:$IMAGE_TAG
+          docker push $ECR_REGISTRY/nyrkio/staging/webhooks:$IMAGE_TAG
           echo "image=$ECR_REGISTRY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
   deployment:
@@ -109,4 +110,4 @@ jobs:
           docker context create $ENV --docker "host=ssh://$SSH_USER@staging.nyrkio.com"
           docker context use $ENV
 
-          docker compose -f docker-compose.yml up --no-build -d nginx backend
+          docker compose -f docker-compose.yml up --no-build -d nginx backend webhooks

--- a/.github/workflows/perf-tests.yml
+++ b/.github/workflows/perf-tests.yml
@@ -57,6 +57,7 @@ jobs:
           # https://stackoverflow.com/a/62436027
           PULL_NUMBER: ${{ github.event.number }}
           GIT_COMMIT: ${{ github.event.pull_request.head.sha }}
+          IMAGE_TAG: ${{ github.event.pull_request.head.sha }}
         run: |
           mv p/frontend/src/static/* p/
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ git submodule init
 git submodule update
 
 cat > .env.backend << END
-DB_URL=mongodb://mongodb:27017/mongodb
+DB_URL=mongodb://mongodb.nyrkio.local:27017/mongodb
 DB_NAME=nyrkiodb
 POSTMARK_API_KEY=
 GITHUB_CLIENT_SECRET=
@@ -65,6 +65,8 @@ SECRET_KEY=
 #GRAFANA_USER=
 #GRAFANA_PASSWORD=
 END
+
+export IMAGE_TAG=$(git rev-parse HEAD)
 
 sudo $PACMAN install docker.io docker-compose-v2
 sudo usermod -a -G docker $USER

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -25,7 +25,7 @@ services:
       - mongodb
 
   webhooks:
-    # build: backend
+    build: backend
     env_file:
       - .env.backend
     environment:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -25,7 +25,7 @@ services:
       - mongodb
 
   webhooks:
-    build: backend
+    # build: backend
     env_file:
       - .env.backend
     environment:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,6 +10,7 @@ services:
     ports:
       - "27017:27017"
     command: mongod --quiet --logpath /dev/null
+
   backend:
     build: backend
     env_file:
@@ -22,6 +23,20 @@ services:
     hostname: api.nyrkio.local
     depends_on:
       - mongodb
+
+  webhooks:
+    build: backend
+    env_file:
+      - .env.backend
+    environment:
+      - API_PORT=8080
+      - GIT_SHA=${IMAGE_TAG}
+    ports:
+      - "8080:8080"
+    hostname: api.nyrkio.local
+    depends_on:
+      - mongodb
+
   nginx:
     build:
       context: ./

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
 
   webhooks:
     image: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/nyrkio/${ENV}/webhooks:${IMAGE_TAG}
-    # build: backend
+    build: webhooks
     env_file:
       - .env.backend
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     hostname: api.nyrkio.local
 
   webhooks:
-    image: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/nyrkio/${ENV}/backend:${IMAGE_TAG}
+    image: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/nyrkio/${ENV}/webhooks:${IMAGE_TAG}
     # build: backend
     env_file:
       - .env.backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,8 @@ services:
     hostname: api.nyrkio.local
 
   webhooks:
-    image: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/nyrkio/${ENV}/webhooks:${IMAGE_TAG}
-    build: webhooks
+    image: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/nyrkio/${ENV}/backend:${IMAGE_TAG}
+    # build: backend
     env_file:
       - .env.backend
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,19 @@ services:
     ports:
       - "8000:8000"
     hostname: api.nyrkio.local
+
+  webhooks:
+    image: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/nyrkio/${ENV}/backend:${IMAGE_TAG}
+    # build: backend
+    env_file:
+      - .env.backend
+    environment:
+      - API_PORT=8080
+      - GIT_SHA=${IMAGE_TAG}
+    ports:
+      - "8080:8080"
+    hostname: api.nyrkio.local
+
   nginx:
     image: ${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/nyrkio/${ENV}/nginx:${IMAGE_TAG}
     build:

--- a/nginx/Dockerfile.dev
+++ b/nginx/Dockerfile.dev
@@ -11,7 +11,7 @@ RUN npm run build
 FROM nginx:1.25
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx/static/ /usr/share/nginx/html
-COPY p/ /usr/share/nginx/html/p
+# COPY p/ /usr/share/nginx/html/p
 EXPOSE 80
 EXPOSE 443
 RUN rm /etc/nginx/conf.d/default.conf

--- a/nginx/nginx-dev.conf
+++ b/nginx/nginx-dev.conf
@@ -6,6 +6,13 @@ server {
 
     access_log off;
 
+    location /api/v0/github/webhook {
+        proxy_pass http://api.nyrkio.local:8080/api/v0/github/webhook;
+    }
+    location /api/v0/github/marketplace-events {
+        proxy_pass http://api.nyrkio.local:8080/api/v0/github/marketplace-events;
+    }
+
     location /api/ {
         add_header 'Access-Control-Allow-Origin' '$http_origin' always;
         add_header 'Access-Control-Allow-Credentials' 'true';
@@ -15,6 +22,10 @@ server {
 
     location /openapi {
         proxy_pass http://api.nyrkio.local:8000/docs;
+    }
+
+    location /p/ {
+        proxy_pass http://nyrkio.com/p/;
     }
 
     location /openapi.json {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -11,6 +11,13 @@ server {
         return 308 $scheme://nyrkio.com/public/https%3A%2F%2Fgithub.com%2F$1;
     }
 
+    location /api/v0/github/webhook {
+        proxy_pass http://api.nyrkio.local:8080/api/v0/github/webhook;
+    }
+    location /api/v0/github/marketplace-events {
+        proxy_pass http://api.nyrkio.local:8080/api/v0/github/marketplace-events;
+    }
+
     location /api/ {
         proxy_pass https://nyrkio.com/api/;
     }
@@ -29,6 +36,12 @@ server {
 
     server_name .xn--nyrki-nua.com;
 
+    location /api/v0/github/webhook {
+        proxy_pass http://api.nyrkio.local:8080/api/v0/github/webhook;
+    }
+    location /api/v0/github/marketplace-events {
+        proxy_pass http://api.nyrkio.local:8080/api/v0/github/marketplace-events;
+    }
     location /api/ {
         proxy_pass https://nyrkio.com/api/;
     }
@@ -68,6 +81,12 @@ server {
     ssl_certificate /etc/nginx/ssl/live/$DOMAIN/fullchain.crt;
     ssl_certificate_key /etc/nginx/ssl/live/$DOMAIN/privkey.key;
 
+    location /api/v0/github/webhook {
+        proxy_pass http://api.nyrkio.local:8080/api/v0/github/webhook;
+    }
+    location /api/v0/github/marketplace-events {
+        proxy_pass http://api.nyrkio.local:8080/api/v0/github/marketplace-events;
+    }
     location /api/ {
         proxy_pass http://api.nyrkio.local:8000/api/;
     }
@@ -91,7 +110,6 @@ server {
         root /usr/share/nginx/html;
         try_files $uri /index.html;
     }
-
 
     proxy_busy_buffers_size 16k;
     proxy_buffer_size 16k;


### PR DESCRIPTION
The two backends are identical, we use nginx config to point /api/v0/github/webhooks to the second.

One reason is that deploying the newly added github runners blocks during ssh, which can take 30ish seconds.

This method can later be used also to simply load balance all api requests between multiple backend instances, ie. making python fastapi "multi-threaded". However, we must remove a few features that currently store state in RAM: the github commit cache, and impresonate are two that I can think of.