### PR TITLE
fix: run.sh doesn't output 10 lines, hence it would always shutdown

### DIFF
--- a/backend/github/remote_scripts.py
+++ b/backend/github/remote_scripts.py
@@ -129,11 +129,9 @@ if [ "$EPHEMERAL" == "--ephemeral" ]
 then
     echo "# This is an --ephemeral instance. Writing to crontab a check to shut down the instance when run.sh marks itself as done." | sudo tee /etc/cron.d/nyrkio-github-runner-done-check
 
-    echo "* * * * * root if [ -e /home/runner/done ]; then echo fake shutdown now; fi" | sudo tee /etc/cron.d/nyrkio-github-runner-done-check
-    echo "* * * * * root sleep 300; if [[ $(cat /home/runner/runsh.stdout.log | wc -l) -gt 10 ]]; then /bin/true; else echo fake shutdown now; fi" | sudo tee /etc/cron.d/nyrkio-github-runner-startup-check
+    echo "* * * * * root if [ -e /home/runner/done ]; then shutdown now; fi" | sudo tee /etc/cron.d/nyrkio-github-runner-done-check
+    echo "* * * * * root sleep 300; if [[ $(grep "Running job" runsh.stdout.log | wc -l) -gte 1 ]]; then /bin/true; else shutdown now; fi" | sudo tee /etc/cron.d/nyrkio-github-runner-startup-check
 fi
-
-cat /etc/cron.d/nyrkio-*
 
 #sudo mv /tmp/runsh_wrapper.sh /home/runner/runsh_wrapper.sh
 sudo chmod a+x /home/runner/runsh_wrapper.sh

--- a/backend/github/runner_configs.py
+++ b/backend/github/runner_configs.py
@@ -30,7 +30,10 @@ LOCAL_FILES = {
     "runsh_wrapper.sh": "/home/runner/runsh_wrapper.sh",
     "wrapper_wrapper.sh": "/home/runner/wrapper_wrapper.sh",
 }
-USER_DATA = "#!/bin/bash\nsudo systemctl enable ssh\nsudo systemctl start ssh\n"
+# This does two things: re-enable ssh because the base image turned it off
+# Before we do anything else, schedule a shutdown to happen 60 odd minutes in the future.
+# This is handy when it can be trusted to just work without any cron or message passing needed.
+USER_DATA = "#!/bin/bash\nsudo systemctl enable ssh\nsudo systemctl start ssh\nsudo shutdown +62\n"
 
 INSTANCE_TYPE_NAME = "nyrkio_perf_server_2cpu_ubuntu2404"
 


### PR DESCRIPTION
Also, just add a shutdown +60 into user data. Now this instance will never live more than  an hour and this won't depend on cron or ssh or anything else.