### PR TITLE
fix: correct MongoDB sort syntax in get_pull_requests

### DIFF
--- a/backend/db/db.py
+++ b/backend/db/db.py
@@ -1262,7 +1262,7 @@ class DBStore(object):
 
             pulls = (
                 await pr_tests.find(query)
-                .sort({"pull_number": -1})
+                .sort("pull_number", -1)
                 .limit(50)
                 .to_list(None)
             )
@@ -1278,7 +1278,7 @@ class DBStore(object):
 
             pulls = (
                 await pr_tests.find(query)
-                .sort({"pull_number": -1})
+                .sort("pull_number", -1)
                 .limit(50)
                 .to_list(None)
             )


### PR DESCRIPTION
## Summary
- Fixed incorrect MongoDB sort syntax in `get_pull_requests` method
- Changed from `.sort({"pull_number": -1})` to `.sort("pull_number", -1))`

## Details
The MongoDB Motor driver expects sort parameters to be passed as positional arguments (field name and direction) rather than as a dictionary. This fixes two occurrences in the `get_pull_requests` method in `backend/db/db.py`.

## Test plan
- Verify that PR queries work correctly
- No change in functionality, only syntax correction

🤖 Generated with [Claude Code](https://claude.com/claude-code)