### PR TITLE
Fix: Allow CPH users to trigger notifications from /public/pull

### DIFF
--- a/backend/db/db.py
+++ b/backend/db/db.py
@@ -505,6 +505,9 @@ class DBStore(object):
         False), raise a DBStoreResultExists exception. Otherwise, update the
         existing result.
         """
+        if isinstance(id, str):
+            id = ObjectId(id)
+
         new_list = [
             DBStore.create_doc_with_metadata(r, id, test_name, pull_number)
             for r in results
@@ -552,7 +555,8 @@ class DBStore(object):
         # if test_name is None:
         #     # Should always be true in our case
         #     test_name = {"$lt":-999}
-
+        if isinstance(id, str):
+            id = ObjectId(id)
         query = {
             "user_id": id,
             "test_name": test_name,
@@ -602,7 +606,7 @@ class DBStore(object):
                 .sort("timestamp")
                 .to_list(None)
             )
-            # print(results)
+        # print(results)
         return separate_meta(results)
 
     async def get_test_names(self, id: Any = None, test_name_prefix: str = None) -> Any:
@@ -1170,7 +1174,10 @@ class DBStore(object):
 
         query = {"pull_request": {"$exists": 1}}
         if user_id is not None:
-            query["user_id"] = user_id
+            if not isinstance(user_id, int):
+                query["user_id"] = ObjectId(user_id)
+            else:
+                query["user_id"] = user_id
         if repo:
             query["attributes.git_repo"] = repo
         if branch:
@@ -1179,6 +1186,8 @@ class DBStore(object):
             query["test_name"] = {"$in": test_names}
         if pull_number:
             query["pull_request"] = pull_number
+        if git_commit:
+            query["attributes.git_commit"] = git_commit
 
         pipeline = [
             {"$match": query},

--- a/backend/tests/test_public_pr_cph_notify.py
+++ b/backend/tests/test_public_pr_cph_notify.py
@@ -133,13 +133,13 @@ def test_public_org_pr_cph_notify(
     json = response.json()
     assert len(json) == 1
 
-    # response = unauthenticated_client.get(
-    #     f"/api/v0/public/pulls/{repo}/{pull_number}/changes/{last_commit}?notify=1",
-    #     headers=headers,
-    # )
-    # assert response.status_code == 200
-    # json = response.json()
-    # assert len(json) == 1
+    response = unauthenticated_client.get(
+        f"/api/v0/public/pulls/{repo}/{pull_number}/changes/{last_commit}?notify=1",
+        headers=headers,
+    )
+    assert response.status_code == 200
+    json = response.json()
+    assert len(json) == 1
 
 
 @patch("backend.auth.challenge_publish.httpx.AsyncClient.get", new_callable=AsyncMock)
@@ -220,7 +220,6 @@ def test_public_user_pr_cph_notify(
     assert response.status_code == 200
 
     last_commit = "12349999"
-
     response = unauthenticated_client.get(
         f"/api/v0/public/pulls/{repo}/{pull_number}/changes/{last_commit}/test/ghuser/tools/main/benchmark1",
         headers=headers,
@@ -274,8 +273,7 @@ def test_public_user_pr_cph_notify(
     )
     assert response.status_code == 200
     json = response.json()
-    # assert len(json) == 1
-    # FIXME
+    assert len(json) == 1
 
 
 @patch("backend.auth.challenge_publish.httpx.AsyncClient.get", new_callable=AsyncMock)
@@ -290,12 +288,11 @@ def test_public_user_fail_pr_cph_notify(
 ):
     mock_sieve.side_effect = lambda repo, commit: commit
     pull_number = 123
-    repo = "ghuser/tools"
     last_commit = "12349999"
 
+    repo = "nyrkio2/tools"
     add_public_results("benchmark1", gh_client, unauthenticated_client, repo)
 
-    repo = "nyrkio2/tools"
     cph_creds, sessionplus = do_cph_auth(
         mock_httpx_client_get, mock_httpx_client_post, unauthenticated_client, repo
     )
@@ -365,7 +362,7 @@ def test_public_user_fail_pr_cph_notify(
         f"/api/v0/public/pulls/{repo}/{pull_number}/changes/{last_commit}/test/ghuser/tools/main/benchmark1?notify=1",
         headers=headers,
     )
-    assert response.status_code == 403
+    assert response.status_code == 404
 
     response = unauthenticated_client.get(
         f"/api/v0/public/pulls/{repo}/{pull_number}/changes/{last_commit}?notify=1",


### PR DESCRIPTION
One end point was untested and broken. In addition inconsistent use of str() and ObjectId() led to situations where newly inserted pr test results would not be found.