### PR TITLE
Runners: Use a Personal Access Token when needing Administrator rights

### DIFF
--- a/backend/db/db.py
+++ b/backend/db/db.py
@@ -1601,6 +1601,17 @@ class DBStore(object):
         print(q, results)
         return results
 
+    async def get_pat(self, user_id):
+        coll = self.db.User
+        u = coll.find_one({"_id": user_id})
+        if len(u) == 1 and u.get("github_pat", None):
+            return u.get("github_pat")
+        return
+
+    async def set_pat(self, user_id, pat):
+        coll = self.db.User
+        coll.update_one({"_id": user_id}, {"github_pat": {"$set": pat}})
+
 
 # Will be patched by conftest.py if we're running tests
 _TESTING = False

--- a/backend/github/runner.py
+++ b/backend/github/runner.py
@@ -89,7 +89,24 @@ async def workflow_job_event(queued_gh_event):
             status_code=401,
             detail="None of {org_name}/{repo_owner}/{sender} were found in Nyrkio. ({nyrkio_org}/{nyrkio_user})",
         )
-    if runner_registration_token is None:
+
+    # To register a self hosted runner for a repo in a users own namespace,
+    # first of all is a different API call, but worst of all, required Administrator permission to
+    # the repo. (e.g. you could delete the entire repo, and so on...)
+    # It's unthinkable that we would ask *all users* to give such permission to our qute little app...
+    # But we still have one lifeline to try: If the user has created a Personal Access Token (fine grained)
+    # we can use it.
+    org_or_user_token = None
+    if nyrkio_user and runner_registration_token is None and org_or_user_repo == "user":
+        store = DBStore()
+        github_pat = await store.get_pat(nyrkio_user)
+        if github_pat:
+            org_or_user_token = github_pat
+
+    elif runner_registration_token is not None and org_or_user_repo == "org":
+        org_or_user_token = runner_registration_token
+
+    else:
         message = f"Did not get a registration token for {org_name}/{repo_owner}/{sender}. Typically this can happen when permission wasn't granted to connect runners with this user or org."
         logger.info(message)
         return {
@@ -103,7 +120,8 @@ async def workflow_job_event(queued_gh_event):
         nyrkio_billing_user,
         queued_gh_event,
         runs_on,
-        runner_registration_token,
+        # runner_registration_token,
+        org_or_user_token,
         org_or_user_repo,
     )
     launched_runners = await launcher.launch()


### PR DESCRIPTION
...to create runners against a personal user repo