### PR TITLE
Add foreground/daemon mode for backend server

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,23 @@ npm run dev
 To run the full stack on your own, use the `docker-compose.dev.yml` file which will start services
 for the proxy (`nginx`), the frontend (`React`Single-page app) and the backend (`FastAPI` app).
 
+Alternatively, you can run the backend and frontend separately using the management scripts:
+
+```console
+# Start backend (foreground mode with logs to stdout)
+python3 etc/nyrkio_backend.py start
+
+# Start backend as daemon (background)
+python3 etc/nyrkio_backend.py start --daemon
+
+# Check status / stop daemon
+python3 etc/nyrkio_backend.py status
+python3 etc/nyrkio_backend.py stop
+
+# Start frontend (connects to local backend by default)
+python3 etc/nyrkio_frontend.py start --mode local
+```
+
 
 ```console
 PACMAN=apt


### PR DESCRIPTION
## Summary
- Backend now runs in **foreground by default** with logs to stdout/stderr (better for development)
- Add `--daemon` flag to run in background (previous default behavior)
- Fix path handling to run correctly from project root
- Update tests for new functionality
- Document usage in README

## Test plan
- [ ] Run `python3 etc/nyrkio_backend.py start` - verify it runs in foreground with logs visible
- [ ] Run `python3 etc/nyrkio_backend.py start --daemon` - verify it backgrounds
- [ ] Run `python3 etc/nyrkio_backend.py status` - verify status reporting works
- [ ] Run `python3 etc/nyrkio_backend.py stop` - verify clean shutdown
- [ ] Run tests: `pytest etc/test_management_scripts.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)